### PR TITLE
fix: make `typing-extensions` a runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog], and this project adheres to [Semantic Versioning][semver].
 
+## [Unreleased]
+
+### Fixed
+
+- Make `typing-extensions` a runtime dependency to fix Python 3.7 usage as some `typing` backports were imported from `typing-extensions`. Python 3.8+ was not affected.
+
 ## [0.2.0] – 2023-05-23
 
 ### Added
@@ -23,5 +29,6 @@ The format is based on [Keep a Changelog][keepachangelog], and this project adhe
 [keepachangelog]: https://keepachangelog.com/en/1.0.0
 [semver]: https://semver.org/spec/v2.0.0.html
 
+[unreleased]: https://github.com/copier-org/jinja2-jsonschema/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/copier-org/jinja2-jsonschema/releases/tag/v0.2.0
 [0.1.0]: https://github.com/copier-org/jinja2-jsonschema/releases/tag/v0.1.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -745,8 +745,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win32.whl", hash = "sha256:763d65baa3b952479c4e972669f679fe490eee058d5aa85da483ebae2009d231"},
     {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win_amd64.whl", hash = "sha256:d000f258cf42fec2b1bbf2863c61d7b8918d31ffee905da62dede869254d3b8a"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:045e0626baf1c52e5527bd5db361bc83180faaba2ff586e763d3d5982a876a9e"},
-    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:1a6391a7cabb7641c32517539ca42cf84b87b667bad38b78d4d42dd23e957c81"},
-    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:9c7617df90c1365638916b98cdd9be833d31d337dbcd722485597b43c4a215bf"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_12_6_arm64.whl", hash = "sha256:721bc4ba4525f53f6a611ec0967bdcee61b31df5a56801281027a3a6d1c2daf5"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:41d0f1fa4c6830176eef5b276af04c89320ea616655d01327d5ce65e50575c94"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-win32.whl", hash = "sha256:f6d3d39611ac2e4f62c3128a9eed45f19a6608670c5a2f4f07f24e8de3441d38"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-win_amd64.whl", hash = "sha256:da538167284de58a52109a9b89b8f6a53ff8437dd6dc26d33b57bf6699153122"},
@@ -949,4 +948,4 @@ yaml = ["pyyaml"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.2"
-content-hash = "acfd4d104fdd3929a9ba38add57f382f4ce899771b70de6374f713395d91839e"
+content-hash = "7e41b1194f601681e183d7bc6b59c1350e7a028bd8d078d384dfb59992243186"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ python = ">=3.7.2"
 jinja2 = ">=3.0.0"
 jsonschema = ">=4.0.0"
 pyyaml = { version = ">=6.0.0", optional = true }
+typing-extensions = { version = ">=3.7.4", python = "<3.8" }
 
 [tool.poetry.extras]
 yaml = ["pyyaml"]
@@ -48,7 +49,6 @@ pytest-cov = ">=4.0.0"
 [tool.poetry.group.typing.dependencies]
 types-jsonschema = ">=4.0.0"
 types-pyyaml = ">=6.0.12.10"
-typing-extensions = { version = ">=3.7.4", python = "<3.8" }
 
 [tool.black]
 target-version = ["py37"]


### PR DESCRIPTION
I've made `typing-extensions` a runtime dependency as `Literal` is imported from there for Python 3.7.