### PR TITLE
ci: pin Poetry v1.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Bootstrap Poetry
-        run: curl -sSL https://install.python-poetry.org | python - -y
+        run: curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
 
       - name: Build project for distribution
         run: poetry build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
         run: echo version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))") >> $GITHUB_OUTPUT
 
       - name: Bootstrap Poetry
-        run: curl -sSL https://install.python-poetry.org | python - -y
+        run: curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
 
       - name: Configure Poetry
         run: poetry config virtualenvs.in-project true


### PR DESCRIPTION
I've pinned Poetry to v1.5 in the CI workflows as Poetry v1.6 dropped support for Python 3.7 and we haven't yet. This is just a workaround until we've dropped Python 3.7 as well.