### PR TITLE
chore: migrate Ruff config to v0.2.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -960,4 +960,4 @@ yaml = ["pyyaml"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.2"
-content-hash = "7e41b1194f601681e183d7bc6b59c1350e7a028bd8d078d384dfb59992243186"
+content-hash = "77c0dfc5f428040ceaf14dd5ce8100b90d1f44e1cb2dc0334a8a268df2a7a570"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ mypy = ">=1.3.0"
 pre-commit = ">=2.21.0"
 pre-commit-hooks = ">=4.4.0"
 pydocstyle = { version = ">=6.3.0", extras = ["toml"] }
-ruff = ">=0.0.267"
+ruff = ">=0.2.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = ">=7.3.1"
@@ -58,7 +58,11 @@ profile = "black"
 force_single_line = true
 
 [tool.ruff]
+src = ["src"]
 line-length = 88
+target-version = "py37"
+
+[tool.ruff.lint]
 ignore = ["D100", "D104", "D107"]
 select = [
   "B",
@@ -84,12 +88,11 @@ select = [
   "UP",
   "W",
 ]
-target-version = "py37"
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.ruff.pylint]
+[tool.ruff.lint.pylint]
 max-args = 7
 
 [tool.mypy]


### PR DESCRIPTION
I've migrated the Ruff config to v0.2.0 according to https://astral.sh/blog/ruff-v0.2.0#configuration-changes.