### PR TITLE
ci: fix checks for Python 3.7 on macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,9 @@ jobs:
             image: windows-latest
           - os: macOS
             image: macos-latest
+          - os: macOS
+            image: macos-12
+            python-version: "3.7"
       fail-fast: false
     defaults:
       run:


### PR DESCRIPTION
I've fixed CI checks for Python 3.7 on macOS by pinning macOS to v12 because the latest version (v14) does not provide Python 3.7 anymore.