### PR TITLE
ci: add runner architecture to cache key

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
         id: cache
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ runner.arch }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install dependencies
         run: poetry install


### PR DESCRIPTION
`macos-latest` has been bumped from macOS 12 (x86_64-based) to macOS 14 (ARM-based). Our current cache key does not contain the runner architecture, so files built for x86_64 might be restored on the ARM runner until that cache gets updated with files built for ARM. So, I've added the architecture of the runner to the cache key which should fix immediate issues and make us more robust against similar changes in the future.