### PR TITLE
build: add support for Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, macOS, Windows]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         include:
           - os: Ubuntu
             image: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 keywords = ["jinja", "jinja2", "extension", "jsonschema", "json", "yaml"]
 authors = ["Sigurd Spieckermann <sigurd.spieckermann@gmail.com>"]


### PR DESCRIPTION
I've added support for Python 3.12 which was released more than a year ago on October 2, 2023. So, officially supporting it, i.e. testing and advertising compatibility, has been long overdue.