### PR TITLE
build(typing): use future annotations and modern typing syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ select = [
 
 [tool.ruff.lint.isort]
 force-single-line = true
+required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/src/jinja2_jsonschema/__init__.py
+++ b/src/jinja2_jsonschema/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .extension import JsonSchemaExtension
 
 __all__ = ["JsonSchemaExtension"]

--- a/src/jinja2_jsonschema/errors.py
+++ b/src/jinja2_jsonschema/errors.py
@@ -1,5 +1,7 @@
 """Error classes."""
 
+from __future__ import annotations
+
 __all__ = [
     "JsonSchemaExtensionError",
     "LoaderNotFoundError",

--- a/src/jinja2_jsonschema/extension.py
+++ b/src/jinja2_jsonschema/extension.py
@@ -1,11 +1,12 @@
 """Jinja2 extension."""
 
+from __future__ import annotations
+
 import json
 from http import HTTPStatus
 from typing import Any
 from typing import Literal
 from typing import Mapping
-from typing import Union
 from urllib.error import HTTPError
 from urllib.parse import urlparse
 from urllib.request import urlopen
@@ -40,7 +41,7 @@ class JsonSchemaExtension(Extension):
         else:
             environment.filters["jsonschema"] = jsonschema_filter
 
-        def jsonschema_test(data: Any, schema: Union[str, _Schema]) -> bool:
+        def jsonschema_test(data: Any, schema: str | _Schema) -> bool:
             return not jsonschema_filter(data, schema)
 
         if "jsonschema" in environment.tests:
@@ -63,8 +64,8 @@ class _JsonSchemaFilter:
         self._environment = environment
 
     def __call__(
-        self, data: Any, schema: Union[str, _Schema]
-    ) -> Union[jsonschema.ValidationError, Literal[""]]:
+        self, data: Any, schema: str | _Schema
+    ) -> jsonschema.ValidationError | Literal[""]:
         """Validate data against a JSON Schema document.
 
         Args:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 """Test configuration."""
 
+from __future__ import annotations
+
 from contextlib import closing
 from functools import partial
 from http.server import SimpleHTTPRequestHandler
@@ -11,7 +13,6 @@ from threading import Thread
 from time import sleep
 from typing import Callable
 from typing import Iterator
-from typing import List
 from typing import cast
 from urllib.error import URLError
 from urllib.request import Request
@@ -42,7 +43,7 @@ def http_server_factory() -> Iterator[HTTPServerFactory]:
         The HTTP server factory.
     """
     server_host = "127.0.0.1"
-    server_disposers: List[Callable[[], None]] = []
+    server_disposers: list[Callable[[], None]] = []
 
     def create(directory: Path) -> str:
         server_port = get_unused_tcp_port()

--- a/tests/filter/test_inline.py
+++ b/tests/filter/test_inline.py
@@ -1,5 +1,7 @@
 """Tests for using inline schemas."""
 
+from __future__ import annotations
+
 from typing import Any
 
 import pytest

--- a/tests/filter/test_local.py
+++ b/tests/filter/test_local.py
@@ -1,6 +1,8 @@
 """Tests for using local schema files."""
 
-from pathlib import Path
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
 
@@ -16,6 +18,9 @@ from tests.utils import create_env
 from tests.utils import serialize
 
 from .utils import TEST_CASES
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.mark.parametrize(("data", "message"), TEST_CASES)

--- a/tests/filter/test_remote.py
+++ b/tests/filter/test_remote.py
@@ -1,19 +1,25 @@
 """Tests for using remote schema files."""
 
-from pathlib import Path
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
 
 import pytest
 
 from jinja2_jsonschema.errors import SchemaFileNotFoundError
-from tests.conftest import HTTPServerFactory
 from tests.utils import SCHEMA
 from tests.utils import build_file_tree
 from tests.utils import create_env
 from tests.utils import serialize
 
 from .utils import TEST_CASES
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from tests.conftest import HTTPServerFactory
 
 
 @pytest.mark.parametrize(("data", "message"), TEST_CASES)

--- a/tests/filter/utils.py
+++ b/tests/filter/utils.py
@@ -1,13 +1,14 @@
 """Testing utilities."""
 
+from __future__ import annotations
+
 from typing import Any
 from typing import Sequence
-from typing import Tuple
 
 from pychoir import Matchable
 from pychoir import MatchesRegex
 
-TEST_CASES: Sequence[Tuple[Any, Matchable]] = [
+TEST_CASES: Sequence[tuple[Any, Matchable]] = [
     (
         {"age": 30},
         "",

--- a/tests/test/test_inline.py
+++ b/tests/test/test_inline.py
@@ -1,5 +1,7 @@
 """Tests for using inline schemas."""
 
+from __future__ import annotations
+
 from typing import Any
 
 import pytest

--- a/tests/test/test_local.py
+++ b/tests/test/test_local.py
@@ -1,6 +1,8 @@
 """Tests for using local schema files."""
 
-from pathlib import Path
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
 
@@ -16,6 +18,9 @@ from tests.utils import create_env
 from tests.utils import serialize
 
 from .utils import TEST_CASES
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.mark.parametrize(("data", "message"), TEST_CASES)

--- a/tests/test/test_remote.py
+++ b/tests/test/test_remote.py
@@ -1,19 +1,25 @@
 """Tests for using remote schema files."""
 
-from pathlib import Path
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
 
 import pytest
 
 from jinja2_jsonschema.errors import SchemaFileNotFoundError
-from tests.conftest import HTTPServerFactory
 from tests.utils import SCHEMA
 from tests.utils import build_file_tree
 from tests.utils import create_env
 from tests.utils import serialize
 
 from .utils import TEST_CASES
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from tests.conftest import HTTPServerFactory
 
 
 @pytest.mark.parametrize(("data", "message"), TEST_CASES)

--- a/tests/test/utils.py
+++ b/tests/test/utils.py
@@ -1,10 +1,11 @@
 """Testing utilities."""
 
+from __future__ import annotations
+
 from typing import Any
 from typing import Sequence
-from typing import Tuple
 
-TEST_CASES: Sequence[Tuple[Any, str]] = [
+TEST_CASES: Sequence[tuple[Any, str]] = [
     ({"age": 30}, "True"),
     ({"age": -1}, "False"),
 ]

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,5 +1,7 @@
 """Tests for adding the extension to the Jinja2 environment."""
 
+from __future__ import annotations
+
 from re import escape
 from typing import Any
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,18 +1,22 @@
 """Testing utilities."""
 
+from __future__ import annotations
+
 import json
-from pathlib import Path
 from textwrap import dedent
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
 from typing import Mapping
-from typing import Optional
 
 import yaml
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
 
 from jinja2_jsonschema import JsonSchemaExtension
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 SCHEMA = {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -27,7 +31,7 @@ SCHEMA = {
 
 
 def serialize(
-    data: Any, data_format: Literal["json", "yaml"], indent: Optional[int] = None
+    data: Any, data_format: Literal["json", "yaml"], indent: int | None = None
 ) -> str:
     """Serialize data to a JSON or YAML string.
 
@@ -49,7 +53,7 @@ def serialize(
     )
 
 
-def create_env(templates_root: Optional[Path] = None) -> Environment:
+def create_env(templates_root: Path | None = None) -> Environment:
     """Create a new Jinja2 test environment.
 
     The Jinja2 environment is pre-configured with the JSON Schema extension and


### PR DESCRIPTION
I've modernized the typing syntax by using future annotations. Now, Ruff via the `isort` rules automatically adds the `from __future__ import annotations` import to each file.