### PR TITLE
chore(ruff): fix Python target version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ types-pyyaml = ">=6.0.12.10"
 [tool.ruff]
 src = ["src"]
 line-length = 88
-target-version = "py37"
+target-version = "py39"
 
 [tool.ruff.lint]
 ignore = ["D100", "D104", "D107", "ISC001"]

--- a/src/jinja2_jsonschema/extension.py
+++ b/src/jinja2_jsonschema/extension.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from http import HTTPStatus
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
-from typing import Mapping
 from urllib.error import HTTPError
 from urllib.parse import urlparse
 from urllib.request import urlopen

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,14 +11,17 @@ from socket import socket
 from socketserver import TCPServer
 from threading import Thread
 from time import sleep
+from typing import TYPE_CHECKING
 from typing import Callable
-from typing import Iterator
 from typing import cast
 from urllib.error import URLError
 from urllib.request import Request
 from urllib.request import urlopen
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 def get_unused_tcp_port() -> int:

--- a/tests/filter/utils.py
+++ b/tests/filter/utils.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Sequence
 
 from pychoir import MatchesRegex
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from pychoir import Matchable
 
 TEST_CASES: Sequence[tuple[Any, Matchable]] = [

--- a/tests/test/utils.py
+++ b/tests/test/utils.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import Any
-from typing import Sequence
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 TEST_CASES: Sequence[tuple[Any, str]] = [
     ({"age": 30}, "True"),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,6 @@ from textwrap import dedent
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
-from typing import Mapping
 
 import yaml
 from jinja2 import Environment
@@ -16,6 +15,7 @@ from jinja2 import FileSystemLoader
 from jinja2_jsonschema import JsonSchemaExtension
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
 SCHEMA = {


### PR DESCRIPTION
I've fixed Ruff's target version for Python and fixed all linter errors. I forgot to bump this version in #118 and 119.