### PR TITLE
chore(pre-commit): migrate config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,14 +45,14 @@ repos:
         entry: trailing-whitespace-fixer
         language: system
         types: [text]
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
 
       - id: end-of-file-fixer
         name: fix end of files
         entry: end-of-file-fixer
         language: system
         types: [text]
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
 
       - id: check-merge-conflict
         name: check for merge conflicts


### PR DESCRIPTION
I've migrated `pre-commit`'s config, as `pre-commit` has deprecated some stage names:

```
[WARNING] hook id `trailing-whitespace` uses deprecated stage names (commit, push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] hook id `end-of-file-fixer` uses deprecated stage names (commit, push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
```