### PR TITLE
chore(deps-dev): remove pydocstyle

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -467,24 +467,6 @@ files = [
 ]
 
 [[package]]
-name = "pydocstyle"
-version = "6.3.0"
-description = "Python docstring style checker"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pydocstyle-6.3.0-py3-none-any.whl", hash = "sha256:118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019"},
-    {file = "pydocstyle-6.3.0.tar.gz", hash = "sha256:7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1"},
-]
-
-[package.dependencies]
-snowballstemmer = ">=2.2.0"
-tomli = {version = ">=1.2.3", optional = true, markers = "python_version < \"3.11\" and extra == \"toml\""}
-
-[package.extras]
-toml = ["tomli (>=1.2.3)"]
-
-[[package]]
 name = "pytest"
 version = "8.3.3"
 description = "pytest: simple powerful testing with Python"
@@ -818,17 +800,6 @@ files = [
 ]
 
 [[package]]
-name = "snowballstemmer"
-version = "2.2.0"
-description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
-optional = false
-python-versions = "*"
-files = [
-    {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
-    {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
-]
-
-[[package]]
 name = "tomli"
 version = "2.0.2"
 description = "A lil' TOML parser"
@@ -901,4 +872,4 @@ yaml = ["pyyaml"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9"
-content-hash = "8b549343fb4a460db6cd58d99805a8b3e35f908129d2132a3393a07ef39a2021"
+content-hash = "5d17b2250440eee1634d4c959e1e5d169f8aeba9182f1741c7912184e75842c1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ yaml = ["pyyaml"]
 mypy = ">=1.3.0"
 pre-commit = ">=2.21.0"
 pre-commit-hooks = ">=4.4.0"
-pydocstyle = { version = ">=6.3.0", extras = ["toml"] }
 ruff = ">=0.2.0"
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
I've removed the unused dev dependency `pydocstyle`. Ruff includes `pydocstyle` rules, so this is just a leftover from migrating to Ruff.