### PR TITLE
refactor: resolve `$ref`s via the `referencing` library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog][keepachangelog], and this project adhe
 ### Changed
 
 - Drop support for Python 3.7 and 3.8.
+- Refactor `$ref` resolution to to use the [`referencing`](https://referencing.readthedocs.io/en/stable/) library instead of the [deprecated `jsonschema.RefResolver` approach](https://github.com/python-jsonschema/jsonschema/releases/tag/v4.18.0).
 
 ## [0.2.1] – 2023-07-11
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ authors = [{ name = "Sigurd Spieckermann", email = "sigurd.spieckermann@gmail.co
 readme = "README.md"
 dependencies = [
   "jinja2>=3.0.0",
-  "jsonschema>=4.0.0"
+  "jsonschema>=4.18.0",
+  "referencing>=0.28.4"
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -166,6 +166,7 @@ source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
     { name = "jsonschema" },
+    { name = "referencing" },
 ]
 
 [package.optional-dependencies]
@@ -189,8 +190,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "jinja2", specifier = ">=3.0.0" },
-    { name = "jsonschema", specifier = ">=4.0.0" },
+    { name = "jsonschema", specifier = ">=4.18.0" },
     { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6.0.0" },
+    { name = "referencing", specifier = ">=0.28.4" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
I've refactored the `$ref` resolution to use the [`referencing`](https://referencing.readthedocs.io/en/stable/) library instead of using the `jsonschema.RefResolver` approach, which has been deprecated since `jsonschema` v4.18.0. See the [v4.18.0 release notes](https://github.com/python-jsonschema/jsonschema/releases/tag/v4.18.0) for more details.

This change should be purely internal.