### PR TITLE
ci(release): attempt avoiding duplicate deployments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: release
 
 on:
+  workflow_dispatch:
   release:
-    types:
-      - published
+    types: [published]
 
 env:
   # renovate: datasource=pypi depName=uv
@@ -13,7 +13,6 @@ jobs:
   build:
     name: Build project for distribution
     runs-on: ubuntu-latest
-    environment: release
 
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +35,8 @@ jobs:
   pypi:
     name: Publish package distributions to PyPI
     runs-on: ubuntu-latest
+    needs: [build]
+    if: github.event_name == "release" && github.event.action == "published"
     environment: release
 
     permissions:


### PR DESCRIPTION
I'm not 100% sure why a release results in two deployments, but I've analyzed the release workflows from some other Python projects and this seems to be a better config. Let's see.