### PR TITLE
chore(ruff): ignore `COM812` rule to avoid formatter conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ line-length = 88
 target-version = "py39"
 
 [tool.ruff.lint]
-ignore = ["D100", "D104", "D107", "ISC001"]
+ignore = ["COM812", "D100", "D104", "D107", "ISC001"]
 select = ["ALL"]
 
 [tool.ruff.lint.flake8-type-checking]


### PR DESCRIPTION
I've added `COM812` to Ruff's ignore list to avoid conflicts with the formatter. Before, Ruff was emitting the following warning:

> warning: The following rule may cause conflicts when used with the formatter: `COM812`. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `ignore` configuration.