### PR TITLE
chore(uv): migrate to PEP 735 dependency-groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,23 +33,25 @@ Repository = "https://github.com/copier-org/jinja2-jsonschema"
 [project.optional-dependencies]
 yaml = ["pyyaml>=6.0.0"]
 
-[tool.uv]
-dev-dependencies = [
-  # dev
+[dependency-groups]
+dev = [
   "mypy==1.13.0",
   "pre-commit==4.0.1",
   "pre-commit-hooks==5.0.0",
-  "ruff==0.7.1",
-
-  # test
+  "ruff==0.7.1"
+]
+test = [
   "pychoir==0.0.27",
   "pytest==8.3.3",
   "pytest-cov==5.0.0",
-
-  # typing
+]
+typing = [
   "types-jsonschema==4.23.0.20240813",
   "types-pyyaml==6.0.12.20240917"
 ]
+
+[tool.uv]
+default-groups = ["dev", "test", "typing"]
 
 [tool.ruff]
 src = ["src"]


### PR DESCRIPTION
I've migrated the dev dependency configuration from `uv`'s legacy [`dev-dependencies`](https://docs.astral.sh/uv/concepts/dependencies/#legacy-dev-dependencies) to the new [PEP 735](https://peps.python.org/pep-0735/) `dependency-groups` which received support by `uv` in [v0.24.7](https://github.com/astral-sh/uv/releases/tag/0.4.27) and by Renovate in [v38.132.0](https://github.com/renovatebot/renovate/releases/tag/38.132.0).