### PR TITLE
ci(release): use single quotes for strings in `if` condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     name: Publish package distributions to PyPI
     runs-on: ubuntu-latest
     needs: [build]
-    if: github.event_name == "release" && github.event.action == "published"
+    if: github.event_name == 'release' && github.event.action == 'published'
     environment: release
 
     permissions:


### PR DESCRIPTION
It seems that GHA requires single quotes (now?) for strings in `if` conditions.