### PR TITLE
chore(renovate): replace custom config by `:maintainLockFilesMonthly` preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    ":maintainLockFilesMonthly",
     ":prHourlyLimitNone",
     "customManagers:githubActionsVersions"
   ],
@@ -10,10 +11,6 @@
   },
   "labels": ["dependencies"],
   "rangeStrategy": "replace",
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": "every 4 week between the 1 and 49 on Monday"
-  },
   "packageRules": [
     {
       "matchCategories": ["python"],


### PR DESCRIPTION
It's cleaner to use the preset, and the preset includes time constraints for lock file maintenance which might work around a bug in Renovate that causes lock file maintenance PRs to reopen :crossed_fingers:.