### PR TITLE
chore(renovate): always use semantic commit type `chore`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "config:recommended",
     ":maintainLockFilesMonthly",
     ":prHourlyLimitNone",
+    ":semanticCommitTypeAll(chore)",
     "customManagers:githubActionsVersions"
   ],
   "pyenv": {


### PR DESCRIPTION
I've configured Renovate to always use the semantic commit type `chore`. Without this setting, updates to runtime dependencies – even when only the lock file is updated – use the commit type `fix` because of the `:semanticPrefixFixDepsChoreOthers` preset included in `config:recommended`. This makes sense for apps or when the version specifier in `pyproject.toml` is updated, but there's no need to include an update only to the lock file in the changelog.