### PR TITLE
chore(config): migrate pytest configuration to `[tool.pytest]` section in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,8 +83,8 @@ max-args = 7
 implicit_reexport = true
 strict = true
 
-[tool.pytest.ini_options]
-addopts = "--cov --cov-report=term-missing"
+[tool.pytest]
+addopts = ["--cov", "--cov-report=term-missing"]
 
 [tool.coverage.run]
 source_pkgs = ["jinja2_jsonschema"]


### PR DESCRIPTION
Starting with pytest [v9.0.0](https://docs.pytest.org/en/stable/changelog.html#pytest-9-0-0-2025-11-05), native TOML configuration is supported including an idiomatic [`[tool.pytest]` section in `pyproject.toml`](https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml). Since [we're already using pytest v9+](https://github.com/copier-org/jinja2-jsonschema/blob/da03804a9942d41f4cc48babdd9b13d9a86aa299/pyproject.toml#L45), I've migrated our pytest configuration accordingly. 